### PR TITLE
fix: support user path with spaces

### DIFF
--- a/slack-theme
+++ b/slack-theme
@@ -176,7 +176,7 @@ then
     pull-css # pull all relevant css files
     if [ "$(uname)" == "Linux" ]
     then
-        chmod 666 $INTEROP_FILE
+        chmod 666 "${INTEROP_FILE}"
     fi
     set-env-vars
     echo "installed successfully"


### PR DESCRIPTION
On windows if the username contains spaces it fails with 
```
chmod: cannot access '/mnt/c/Users/John': No such file or directory
chmod: cannot access 'Doe/AppData/Local/slack/app-3.4.0/resources/app.asar.unpacked/src/static/ssb-interop.js': No such file or directory
```